### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   	"test": "vows tests.js"
   },
   "devDependencies"  : {
-                          "vows"      : "0.7.0"
+                          "vows"      : "0.8.x"
                         },
   "main"              : "./ERR",
   "version"           : "0.0.4"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "description"       : "Improves node.js stacktraces and makes it easier to handle errors",
   "homepage"          : "https://github.com/Pita/async-stacktrace",
   "author"            : "Peter 'Pita' Martischka <petermartischka@googlemail.com>",
+  "scripts": {
+  	"test": "vows tests.js"
+  },
   "devDependencies"  : {
-                          "vows"      : "0.6.0"
+                          "vows"      : "0.7.0"
                         },
   "main"              : "./ERR",
   "version"           : "0.0.4"

--- a/tests.js
+++ b/tests.js
@@ -67,18 +67,19 @@ vows.describe('ERR function').addBatch({
       
       var stackLinesAfter = errorAfter.stack.split("\n").length;
       
-      assert.equal(stackLinesBefore+3, stackLinesAfter);
+      var delimiter = 1;
+      var num_lines_stripped = 2;
+      assert.equal(stackLinesAfter, stackLinesBefore + delimiter + (stackLinesBefore - num_lines_stripped));
     }
   },
   'when you give it a async stacktrace': {
     'it adds a new stack line' : function(){
       var err = new Error();
+      var stackLinesBefore = err.stack.split("\n").length;
       
       ERR(err, function(_err){
         err = _err;
       });
-      
-      var stackLinesBefore = err.stack.split("\n").length;
       
       ERR(err, function(_err){
         err = _err;
@@ -86,7 +87,9 @@ vows.describe('ERR function').addBatch({
       
       var stackLinesAfter = err.stack.split("\n").length;
       
-      assert.equal(stackLinesBefore+1, stackLinesAfter);
+      var delimiter = 1;
+      var num_lines_stripped = 2;
+      assert.equal(stackLinesAfter, stackLinesBefore + delimiter + (stackLinesBefore - num_lines_stripped) + delimiter + (stackLinesBefore - num_lines_stripped));
     }
   },
   'when you call it with a callback as the only argument': {

--- a/tests.js
+++ b/tests.js
@@ -127,4 +127,4 @@ vows.describe('ERR function').addBatch({
       wrappedCallback.call("test_this", err, "arg1", "arg2");
     }
   }
-}).run();    
+}).export(module);    

--- a/tests.js
+++ b/tests.js
@@ -104,11 +104,14 @@ vows.describe('ERR function').addBatch({
       var asyncLineNumber;
       var wrappedCallback = ERR(function(_err) {
         stackLinesAfter = _err.stack.split("\n");
-        asyncLineNumber = lineNumberRegex.exec(stackLinesAfter[1])[1];
+        asyncLineNumber = lineNumberRegex.exec(stackLinesAfter[stackLinesAfter.length - 1])[1];
       });
 
       wrappedCallback(err);
-      assert.equal(stackLinesBefore.length+3, stackLinesAfter.length);
+
+      var delimiter = 1;
+      var num_new_lines = 1;
+      assert.equal(stackLinesAfter.length, stackLinesBefore.length + delimiter + num_new_lines);
 
       // because `ERR(...)` is 6 lines after `new Error()` in this test
       assert.equal(parseInt(asyncLineNumber), parseInt(syncLineNumber)+6);


### PR DESCRIPTION
Updated tests so they pass:

* Updated vows to 0.8.x (b/c 0.6.x doesn't work in node 0.10+)
* Updated tests for vows 0.8.x (`export(module) instead of `run()`)
* Updated 3 tests for the full-stack changes in cf5f0bb17

**Note**: for some reason `npm install` didn't update it for me, I had to manually delete the folder & then `npm install`)